### PR TITLE
dip-0073 - For The Miners

### DIFF
--- a/dip-0073.mediawiki
+++ b/dip-0073.mediawiki
@@ -1,0 +1,58 @@
+<pre>
+  DIP: 73
+  Title: For the Miners
+  Author: Gene Redinger <gene.redinger@gmail.com>
+  Status: Draft
+  Type: Standards Track
+  Created: 2020-04-04
+</pre>
+
+==Abstract==
+
+This DIP increase mining rewards from the existing 10,000 flat reward to 25,000 dogecoin flat reward.
+
+==Motivation==
+
+Many economic and specutative groups have taken the coin and turned it into something it was never meant
+to be. The community has the right to express their thoughts on this issue by taking direct action in creating
+a more friendly ecosystem for miners and users without adding in additional benefits for the speculators.
+
+This DIP is meant to be introduced alongside DIP 74 to allow for a more equiable network.
+
+== Protocol ==
+
+This DIP describes a change in the underlying core code for reward calculation. The change will occur at 2^22 block.
+
+<pre>
+if (!consensusParams.fSimplifiedRewards)
+    {
+        // Old-style rewards derived from the previous block hash
+        const std::string cseed_str = prevHash.ToString().substr(7, 7);
+        const char* cseed = cseed_str.c_str();
+        char* endp = NULL;
+        long seed = strtol(cseed, &endp, 16);
+        CAmount maxReward = (1000000 >> halvings) - 1;
+        int rand = generateMTRandom(seed, maxReward);
+
+        return (1 + rand) * COIN;
+    } else if (nHeight < (6 * consensusParams.nSubsidyHalvingInterval)) {
+        // New-style constant rewards for each halving interval
+        return (500000 * COIN) >> halvings;
+    } else if (nHeight >= (1 << 22)) { // on block 4,194,304
+        return 25000 * COIN; // increase reward to 25,000
+    } else {
+        // Constant inflation
+        return 10000 * COIN;
+    }
+</pre>
+
+== Speculative Impacts ==
+
+The economic market may respond negatively to the announced increase in supply of the crypto. This could lead to
+more violitile markets leading up to the change.
+
+However, 1 doge will be 1 doge rather it's minted from block 2^0 or 2^128.
+
+== Security Impacts ==
+
+This DIP does not impact the security of the network in terms of availability, confidentiality, and integrity.

--- a/dip-0074.medawiki
+++ b/dip-0074.medawiki
@@ -1,0 +1,54 @@
+<pre>
+  DIP: 74
+  Title: For the Users
+  Author: Gene Redinger <gene.redinger@gmail.com>
+  Status: Draft
+  Type: Standards Track
+  Created: 2020-04-04
+</pre>
+
+==Abstract==
+
+This DIP reduces the transaction fee from 1 DOGE to .05 DOGE per KB for min transaction fee.
+
+==Motivation==
+
+Many economic and specutative groups have taken the coin and turned it into something it was never meant
+to be. The community has the right to express their thoughts on this issue by taking direct action in creating
+a more friendly ecosystem for miners and users without adding in additional benefits for the speculators.
+
+This DIP is meant to be introduced alongside DIP 73 to allow for a more equiable network.
+
+== Protocol ==
+
+This DIP describes another change in the underlying core code for fee. There is no governance for this change to take affect.
+
+It is suggested that the community manually update their fee amount until the change is made in core.
+
+<pre>
+static const unsigned int DEFAULT_MIN_RELAY_TX_FEE = COIN/20;
+</pre>
+
+== Speculative Impacts ==
+
+The average network fee may or may not increase depending on the size of the mempool.
+
+== Security Impacts ==
+
+This DIP has security implication in terms of availability of the netwrok.
+
+By reducing the overall transaction fee, this allows for a malciious user to use "dust" transactions
+to effectively prevent new transactions from being recorded. This attack was previously used to prevent
+transactions on the network which lead to the original fee increase.
+
+However, since the change was originally made, the real world economics shifted in regard to the coin's security.
+
+Attacks on the networks are still currently feasible with nation state resources with current fees.
+
+---
+
+The availability of transactions may be impacted due to some clients not being updated
+and therefore client transactions with lower fees being rejected.
+
+This issue can be mitigated by using the manual flag early allowing for the users on the
+community to accept lower fee transactions early.


### PR DESCRIPTION
Overview: Many economic and speculative groups have taken the coin and turned it into something it was never meant
to be. The community has the right to express their thoughts on this issue by taking direct action in creating
a more friendly ecosystem for miners and users without adding in additional benefits for the speculators.

DIP 0073: For the Miners - Increases rewards to 25,000 after block height reaches 4,194,304.

